### PR TITLE
chore: ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .next
 .vscode
+yarn.lock
 out


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
-->



**What does this PR do?**

The repository uses `npm`, hence ignoring `yarn.lock` to avoid someone (new contributors) committing `yarn.lock` if he accidentally installed deps using yarn.

**Any background context you want to provide?**
I have seen many times people committing package-lock files for yarn based repo and vice-versa and then the changes appear in PR and then we have to ask them to remove and use npm/yarn.
So better we ignore it.
**Screenshots?**
NA