### PR TITLE
fix: use appropriate name for eslint script

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,4 +25,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm test
+    - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "export": "next export",
-    "test": "eslint src/**/* pages/**/* --ext .jsx,.js  --fix"
+    "lint": "eslint src/**/* pages/**/* --ext .jsx,.js  --fix"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
-->
Fixes #33 

This PR solves issue #33 

**What does this PR do?**

renamed script. used more appropriate naming.

~~`npm run test`~~ => `npm run lint`


**Any background context you want to provide?**
NA
**Screenshots?**
NA