### PR TITLE
Minor CSS fix for Card Tags in Feed Page

### DIFF
--- a/src/components/FeedCard.jsx
+++ b/src/components/FeedCard.jsx
@@ -45,26 +45,18 @@ export default function Card() {
             <div className={styles.flex}>
               <div className={styles['smallbox-below']}>
                 <div className={styles.flex}>
-                  <div>
                     <img
                       src="SVG/Icon awesome-exclamation-circle.svg"
                       alt="issue"
                     />
-                  </div>
-                  <div>
                     <p>Issues:13</p>
-                  </div>
                 </div>
               </div>
               <div>
                 <div className={styles['smallbox-below']}>
                   <div className={styles.flex}>
-                    <div>
                       <img src="SVG/pr.svg" alt="pr" />
-                    </div>
-                    <div>
                       <p>PR:1233</p>
-                    </div>
                   </div>
                 </div>
               </div>

--- a/src/scss/card.module.scss
+++ b/src/scss/card.module.scss
@@ -41,7 +41,7 @@
   font-weight: 600;
   border-radius: 1.25rem;
   box-shadow: $box-shadow-dark;
-  height: 1.875rem;
+  padding: 0.25rem 0.5rem;
   margin-right: 0.625rem;
 }
 

--- a/src/scss/card.module.scss
+++ b/src/scss/card.module.scss
@@ -51,6 +51,9 @@
   justify-content: center;
   align-items: center;
 }
+.smallbox-below > .flex > img {
+  margin-right: 0.2rem;
+}
 .save {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
-->

This PR solves issue : Card Tags for Issues and PR were misaligned in feed page.

**Screenshots?**

![image](https://user-images.githubusercontent.com/41316371/84254595-0db50080-ab2f-11ea-8ecb-cc8a5c4f02a0.png)
